### PR TITLE
Fix mocked service

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ before do
 end
 ```
 
+If your'e testing a sign-in flow:
+
+```ruby
+scenario 'sign-in' do
+  # Simulate that the user will sign-in at the SSO site:
+  Icalia::StubbedSSOService.sign_in_on_authorize
+  visit root_path # or any path in your app that requires authentication
+
+  #...
+end
+```
+
+If your'e testing a sign-out flow:
+
+```ruby
+scenario 'sign-out' do
+  # Simulate that the user will sign-in at the SSO site:
+  Icalia::StubbedSSOService.sign_in_on_authorize
+  visit root_path # or any path in your app that requires authentication
+
+  # Simulate that the user won't sign-in at the SSO site:
+  Icalia::StubbedSSOService.do_not_sign_in_on_authorize
+  click_link 'Logout'
+
+  # The message coming from Artanis & the Fake Artanis "StubbedSSOService":
+  expect(page).to have_content 'Signed out successfully.'
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/icalia/stubbed_sso_service.rb
+++ b/lib/icalia/stubbed_sso_service.rb
@@ -116,6 +116,10 @@ module Icalia
       def store_oauth_flow_data(data)
         oauth_flows << data
       end
+
+      def url
+        "http://localhost:#{server_port}"
+      end
     
       # Taken from FakeStripe.stub_stripe at fake_stripe gem: 
       def prepare
@@ -127,11 +131,9 @@ module Icalia
         # the Sinatra app instead of just stubbing the app with WebMock...
         boot_once
 
-        oauth_host = "http://localhost:#{server_port}"
-
         OmniAuth::Strategies::Icalia.instances.each do |strategy|
           strategy.options.client_options.tap do |options|
-            options.site = oauth_host
+            options.site = url
             options.token_url = "#{oauth_host}/oauth/token"
             options.authorize_url = "#{oauth_host}/oauth/authorize"
           end

--- a/lib/icalia/stubbed_sso_service.rb
+++ b/lib/icalia/stubbed_sso_service.rb
@@ -121,8 +121,6 @@ module Icalia
       def prepare
         reset
     
-        yield self if block_given?
-    
         # Since the OAuth flow is performed by the browser, we'll need to boot
         # the Sinatra app instead of just stubbing the app with WebMock...
         boot_once
@@ -135,6 +133,8 @@ module Icalia
           client_options.token_url = "#{oauth_host}/oauth/token"
           client_options.authorize_url = "#{oauth_host}/oauth/authorize"
         end
+    
+        yield self if block_given?
       end
 
       def teardown

--- a/lib/icalia/stubbed_sso_service.rb
+++ b/lib/icalia/stubbed_sso_service.rb
@@ -128,10 +128,11 @@ module Icalia
         oauth_host = "http://localhost:#{server_port}"
 
         OmniAuth::Strategies::Icalia.instances.each do |options|
-          client_options = options.client_options
-          client_options.site = oauth_host
-          client_options.token_url = "#{oauth_host}/oauth/token"
-          client_options.authorize_url = "#{oauth_host}/oauth/authorize"
+          options.client_options.tap do |client_options|
+            client_options.site = oauth_host
+            client_options.token_url = "#{oauth_host}/oauth/token"
+            client_options.authorize_url = "#{oauth_host}/oauth/authorize"
+          end
         end
     
         yield self if block_given?
@@ -143,10 +144,11 @@ module Icalia
           .client_options
 
         OmniAuth::Strategies::Icalia.instances.each do |options|
-          client_options = options.client_options
-          client_options.site = default_client_options.site
-          client_options.token_url = default_client_options.token_url
-          client_options.authorize_url = default_client_options.authorize_url
+          options.client_options.tap do |client_options|
+            client_options.site = default_client_options.site
+            client_options.token_url = default_client_options.token_url
+            client_options.authorize_url = default_client_options.authorize_url
+          end
         end
       end
 

--- a/lib/icalia/stubbed_sso_service.rb
+++ b/lib/icalia/stubbed_sso_service.rb
@@ -120,34 +120,34 @@ module Icalia
       # Taken from FakeStripe.stub_stripe at fake_stripe gem: 
       def prepare
         reset
-    
+
+        yield self if block_given?
+
         # Since the OAuth flow is performed by the browser, we'll need to boot
         # the Sinatra app instead of just stubbing the app with WebMock...
         boot_once
-    
+
         oauth_host = "http://localhost:#{server_port}"
 
-        OmniAuth::Strategies::Icalia.instances.each do |options|
-          options.client_options.tap do |client_options|
-            client_options.site = oauth_host
-            client_options.token_url = "#{oauth_host}/oauth/token"
-            client_options.authorize_url = "#{oauth_host}/oauth/authorize"
+        OmniAuth::Strategies::Icalia.instances.each do |strategy|
+          strategy.options.client_options.tap do |options|
+            options.site = oauth_host
+            options.token_url = "#{oauth_host}/oauth/token"
+            options.authorize_url = "#{oauth_host}/oauth/authorize"
           end
         end
-    
-        yield self if block_given?
       end
 
       def teardown
         default_client_options = OmniAuth::Strategies::Icalia
           .default_options
           .client_options
-
-        OmniAuth::Strategies::Icalia.instances.each do |options|
-          options.client_options.tap do |client_options|
-            client_options.site = default_client_options.site
-            client_options.token_url = default_client_options.token_url
-            client_options.authorize_url = default_client_options.authorize_url
+  
+        OmniAuth::Strategies::Icalia.instances.each do |strategy|
+          strategy.options.client_options.tap do |options|
+            options.site = default_client_options.site
+            options.token_url = default_client_options.token_url
+            options.authorize_url = default_client_options.authorize_url
           end
         end
       end

--- a/lib/omniauth/strategies/icalia.rb
+++ b/lib/omniauth/strategies/icalia.rb
@@ -19,9 +19,9 @@ module OmniAuth
       end
 
       def initialize(*args)
-        instance = super(*args)
-        @@instances << instance
-        instance
+        ret = super
+        @@instances << self
+        ret
       end
 
       def request_phase


### PR DESCRIPTION
Fixes strategy reconfiguration not working at all whenever the test app was being loaded by "rails spring" with the original configuration, never touched by the configuration made when calling `.prepare`